### PR TITLE
Pass missing secret to reusable workflow

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     uses: canonical/observability/.github/workflows/rock-update.yaml@v0
+    secrets:
+      OBSERVABILITY_NOCTUA_TOKEN: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
     with:
       rock-name: karma
       source-repo: prymitive/karma


### PR DESCRIPTION
## Issue
Update-rock [workflow](https://github.com/canonical/karma-rock/actions/runs/15671676633) ([v0](https://github.com/canonical/observability/blob/v0/.github/workflows/rock-update.yaml)) is failing because OBSERVABILITY_NOCTUA_TOKEN is missing.


## Solution
Pass missing secret to reusable workflow.
Ref: https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#passing-inputs-and-secrets-to-a-reusable-workflow
